### PR TITLE
run apt-get update before apt-get install

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -50,7 +50,7 @@ describe('upterm GitHub integration', () => {
     await run();
 
     expect(mockedExecShellCommand).toHaveBeenNthCalledWith(1, 'curl -sL https://github.com/owenthereal/upterm/releases/latest/download/upterm_linux_amd64.tar.gz | tar zxvf - -C /tmp upterm && sudo install /tmp/upterm /usr/local/bin/');
-    expect(mockedExecShellCommand).toHaveBeenNthCalledWith(2, 'if ! command -v tmux &>/dev/null; then sudo apt-get -y install tmux; fi');
+    expect(mockedExecShellCommand).toHaveBeenNthCalledWith(2, 'if ! command -v tmux &>/dev/null; then sudo apt-get update && sudo apt-get -y install tmux; fi');
 
     expect(core.info).toHaveBeenNthCalledWith(1, 'Auto-generating ~/.ssh/known_hosts by attempting connection to uptermd.upterm.dev');
     expect(core.info).toHaveBeenNthCalledWith(2, 'Creating a new session. Connecting to upterm server ssh://myserver:22');
@@ -73,7 +73,7 @@ describe('upterm GitHub integration', () => {
     await run();
 
     expect(mockedExecShellCommand).toHaveBeenNthCalledWith(1, 'curl -sL https://github.com/owenthereal/upterm/releases/latest/download/upterm_linux_amd64.tar.gz | tar zxvf - -C /tmp upterm && sudo install /tmp/upterm /usr/local/bin/');
-    expect(mockedExecShellCommand).toHaveBeenNthCalledWith(2, 'if ! command -v tmux &>/dev/null; then sudo apt-get -y install tmux; fi');
+    expect(mockedExecShellCommand).toHaveBeenNthCalledWith(2, 'if ! command -v tmux &>/dev/null; then sudo apt-get update && sudo apt-get -y install tmux; fi');
     expect(core.info).toHaveBeenNthCalledWith(1, 'Appending ssh-known-hosts to ~/.ssh/known_hosts. Contents of ~/.ssh/known_hosts:');
     expect(core.info).toHaveBeenNthCalledWith(2, `${customConnectionString}`);
     expect(core.info).toHaveBeenNthCalledWith(3, 'Creating a new session. Connecting to upterm server ssh://myserver:22');

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,7 @@ export async function run() {
     core.debug('Installing dependencies');
     if (process.platform == 'linux') {
       await execShellCommand(`curl -sL https://github.com/owenthereal/upterm/releases/latest/download/upterm_linux_amd64.tar.gz | tar zxvf - -C /tmp upterm && sudo install /tmp/upterm /usr/local/bin/`);
-      await execShellCommand('if ! command -v tmux &>/dev/null; then sudo apt-get -y install tmux; fi');
+      await execShellCommand('if ! command -v tmux &>/dev/null; then sudo apt-get update && sudo apt-get -y install tmux; fi');
     } else {
       await execShellCommand('brew install owenthereal/upterm/upterm tmux');
     }


### PR DESCRIPTION
When `tmux` is missing, not running `update` before `apt-get install`, will cause the install to fail:

```
$ sudo apt-get install -y tmux
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
| E: Unable to locate package tmux
```