### PR TITLE
e2e: fix SSH command regex to match current upterm output format

### DIFF
--- a/e2e/utils.ts
+++ b/e2e/utils.ts
@@ -28,8 +28,8 @@ export function runActWorkflow(): {
       console.log('[act stdout]', chunk);
 
       // Look for SSH command in upterm output - matches upterm.dev domain specifically
-      // Example: "│ ➤ SSH Command:   │ ssh d07zbpLrcE4LxtHM3wKn@uptermd.upterm.dev          │"
-      const sshMatch = chunk.match(/SSH Command:[^\n]*?(ssh\s+\S+@uptermd\.upterm\.dev)/i);
+      // Example: "SSH command available as output: ssh IYPwJpVLifTKRNowOUuV@uptermd.upterm.dev"
+      const sshMatch = chunk.match(/SSH command[^:]*:[^\n]*?(ssh\s+\S+@uptermd\.upterm\.dev)/i);
       if (sshMatch && !settled) {
         settled = true;
         clearTimeout(timeout);


### PR DESCRIPTION
The e2e test's regex for detecting the SSH connection string in act's stdout used the pattern `SSH Command:`, which matched the old tablewriter-based output from upterm (e.g. `│ ➤ SSH Command:   │ ssh TOKEN@uptermd.upterm.dev │`).

In owenthereal/upterm#433 (merged 2026-01-06) the session display was replaced with a Bubbletea/Lipgloss TUI, changing the layout. The action's own `core.info()` call still emits `SSH command available as output: ssh TOKEN@…` on a single line, but the old regex doesn't match because the colon no longer appears directly after the word "command".

This relaxes the regex from `SSH Command:` to `SSH command[^:]*:` so it accepts any characters between "command" and the colon, matching both the old and current formats.