### PR TITLE
e2e: fix Jest warning about open handles after test run

### DIFF
--- a/e2e/utils.ts
+++ b/e2e/utils.ts
@@ -71,6 +71,7 @@ export function runActWorkflow(): {
         }
         forceKillTimeout = null;
       }, 5000);
+      forceKillTimeout.unref();
     } else if (forceKillTimeout) {
       clearTimeout(forceKillTimeout);
       forceKillTimeout = null;

--- a/e2e/utils.ts
+++ b/e2e/utils.ts
@@ -28,8 +28,8 @@ export function runActWorkflow(): {
       console.log('[act stdout]', chunk);
 
       // Look for SSH command in upterm output - matches upterm.dev domain specifically
-      // Example: "│ ➤ SSH Command:   │ ssh d07zbpLrcE4LxtHM3wKn@uptermd.upterm.dev          │"
-      const sshMatch = chunk.match(/SSH Command:[^\n]*?(ssh\s+\S+@uptermd\.upterm\.dev)/i);
+      // Example: "SSH command available as output: ssh IYPwJpVLifTKRNowOUuV@uptermd.upterm.dev"
+      const sshMatch = chunk.match(/SSH command[^:]*:[^\n]*?(ssh\s+\S+@uptermd\.upterm\.dev)/i);
       if (sshMatch && !settled) {
         settled = true;
         clearTimeout(timeout);


### PR DESCRIPTION
**Note:** This PR is stacked on top of #29 and should be reviewed/merged after it.

This addresses the following warning when running the e2e tests:

> Jest did not exit one second after the test run has completed.
>
> This usually means that there are asynchronous operations that weren't stopped in your tests. Consider running Jest with `--detectOpenHandles` to troubleshoot this issue.
