### PR TITLE
Update Node Version and Workflow Actions to Node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,8 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 22.x
           cache: yarn
@@ -36,8 +36,8 @@ jobs:
   e2e:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 22.x
           cache: yarn

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: 22.x
+          node-version: 24.x
           cache: yarn
       - run: yarn install --frozen-lockfile
       - run: yarn test
@@ -39,7 +39,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: 22.x
+          node-version: 24.x
           cache: yarn
       - name: Install act
         run: |

--- a/.github/workflows/dogfood.yml
+++ b/.github/workflows/dogfood.yml
@@ -6,7 +6,7 @@ jobs:
   upterm:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Start upterm session
         uses: ./
         with:

--- a/.github/workflows/e2e-fixture-detached.yml
+++ b/.github/workflows/e2e-fixture-detached.yml
@@ -7,7 +7,7 @@ jobs:
   upterm:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Start upterm session (detached)
         id: upterm

--- a/.github/workflows/e2e-fixture.yml
+++ b/.github/workflows/e2e-fixture.yml
@@ -9,7 +9,7 @@ jobs:
     outputs:
       ssh-command: ${{ steps.upterm.outputs.ssh-command }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Start upterm session
         id: upterm

--- a/.github/workflows/manual-test.yml
+++ b/.github/workflows/manual-test.yml
@@ -54,7 +54,7 @@ jobs:
           # here step... However, by using `C:\.\` we can fool that
           # overzealous check.
           location: C:\.\
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./
         with:
           limit-access-to-actor: ${{ inputs.limit-access-to-actor }}
@@ -64,7 +64,7 @@ jobs:
     container:
       image: ${{ inputs.container-runs-on }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./
         with:
           limit-access-to-actor: ${{ inputs.limit-access-to-actor }}

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v6
     - name: Setup upterm session
       uses: owenthereal/action-upterm@v1
 ```
@@ -42,7 +42,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v6
     - name: Setup upterm session
       uses: owenthereal/action-upterm@v1
       with:
@@ -64,7 +64,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v6
     - name: Setup upterm session
       uses: owenthereal/action-upterm@v1
       with:
@@ -83,7 +83,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v6
     - name: Setup upterm session
       uses: owenthereal/action-upterm@v1
       with:
@@ -104,7 +104,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v6
     - name: Setup upterm session
       uses: owenthereal/action-upterm@v1
       if: ${{ failure() }}
@@ -124,7 +124,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v6
     - name: Setup upterm session
       uses: owenthereal/action-upterm@v1
       with:

--- a/action.yml
+++ b/action.yml
@@ -5,7 +5,7 @@ branding:
   icon: "terminal"
   color: "purple"
 runs:
-  using: "node20"
+  using: "node24"
   main: "lib/index.js"
   post: "lib/index.js"
   post-if: "!cancelled()"

--- a/detached/action.yml
+++ b/detached/action.yml
@@ -5,7 +5,7 @@ branding:
   icon: "terminal"
   color: "purple"
 runs:
-  using: "node20"
+  using: "node24"
   main: "../lib/index.js"
   post: "../lib/index.js"
   post-if: "!cancelled()"


### PR DESCRIPTION
Node 20 is going to be EOL at end of April and as part of that Github is in the process of deprecating Node 20 on GitHub Actions runners. On June 2nd runners will be using Node 24 by default and Github has started printing warnings when Node 20 actions are run. This PR bumps the version to Node 24 and workflow actions to the latest Node 24 versions.

More info here:
https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/  